### PR TITLE
Allow AstroRuntimeVersion to be optional

### DIFF
--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -72,7 +72,7 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 		Attributes: map[string]schema.Attribute{
 			"astro_runtime_version": schema.StringAttribute{
 				MarkdownDescription: "Deployment's Astro Runtime version.",
-				Required:            true,
+				Optional:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},


### PR DESCRIPTION
AstroRuntimeVersion must be set on create, but there is no way to get this from the API after it's set, so this makes it impossible to import an existing deployment.
I relax the restriction to pass it in, and let the API client throw the error in runtime if the user mis-configures it.