### PR TITLE
Add Remaining Deployment Variables

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -20,7 +20,7 @@ resource "astronomer_deployment" "standard_deployment" {
   default_task_pod_memory = "1Gi"
   description             = "A Standard Deployment"
   executor                = "CELERY"
-  is_dag_deploy_enforced  = true
+  is_dag_deploy_enabled   = true
   is_cicd_enforced        = true
   is_high_availability    = true
   name                    = "Test Deployment TF"
@@ -40,6 +40,18 @@ resource "astronomer_deployment" "standard_deployment" {
       worker_concurrency : 1,
     },
   ]
+  environment_variables = [
+    {
+      is_secret : true,
+      key : "AWS_ACCESS_SECRET_KEY",
+      value : "SECRET_VALUE",
+    },
+    {
+      is_secret : false,
+      key : "AWS_ACCESS_KEY_ID",
+      value : "NOT_SECRET",
+    },
+  ]
 }
 ```
 
@@ -48,12 +60,11 @@ resource "astronomer_deployment" "standard_deployment" {
 
 ### Required
 
-- `astro_runtime_version` (String) Deployment's Astro Runtime version.
 - `default_task_pod_cpu` (String) The default CPU resource usage for a worker Pod when running the Kubernetes executor or KubernetesPodOperator. Units are in number of CPU cores.
 - `default_task_pod_memory` (String) The default memory resource usage for a worker Pod when running the Kubernetes executor or KubernetesPodOperator. Units are in `Gi`. This value must always be twice the value of `DefaultTaskPodCpu`.
 - `executor` (String) The Deployment's executor type.
 - `is_cicd_enforced` (Boolean) Whether the Deployment requires that all deploys are made through CI/CD.
-- `is_dag_deploy_enforced` (Boolean) Whether the Deployment has DAG deploys enabled.
+- `is_dag_deploy_enabled` (Boolean) Whether the Deployment has DAG deploys enabled.
 - `is_high_availability` (Boolean) Whether the Deployment is configured for high availability. If `true`, multiple scheduler pods will be online.
 - `name` (String) The Deployment's name.
 - `resource_quota_cpu` (String) The CPU quota for worker Pods when running the Kubernetes executor or KubernetesPodOperator. If current CPU usage across all workers exceeds the quota, no new worker Pods can be scheduled. Units are in number of CPU cores.
@@ -64,16 +75,32 @@ resource "astronomer_deployment" "standard_deployment" {
 
 ### Optional
 
+- `astro_runtime_version` (String) Deployment's Astro Runtime version.
 - `cloud_provider` (String) The cloud provider for the Deployment's cluster. Optional if `ClusterId` is specified.
 - `cluster_id` (String) The ID of the cluster where the Deployment will be created.
 - `description` (String) The Deployment's description.
+- `environment_variables` (Attributes List) List of environment variables to add to the Deployment. (see [below for nested schema](#nestedatt--environment_variables))
 - `region` (String) The region to host the Deployment in. Optional if `ClusterId` is specified.
+- `task_pod_node_pool_id` (String) The node pool ID for the task pods. For KUBERNETES executor only.
 - `worker_queues` (Attributes List) The list of worker queues configured for the Deployment. Applies only when `Executor` is `CELERY`. At least 1 worker queue is needed. All Deployments need at least 1 worker queue called `default`. (see [below for nested schema](#nestedatt--worker_queues))
 
 ### Read-Only
 
 - `id` (String) The Deployment's identifier.
 - `workload_identity` (String) The Deployment's workload identity.
+
+<a id="nestedatt--environment_variables"></a>
+### Nested Schema for `environment_variables`
+
+Required:
+
+- `is_secret` (Boolean) Whether the environment variable is a secret.
+- `key` (String) The environment variable key, used to call the value in code.
+
+Optional:
+
+- `value` (String, Sensitive) The environment variable value.
+
 
 <a id="nestedatt--worker_queues"></a>
 ### Nested Schema for `worker_queues`

--- a/examples/resources/astronomer_deployment/resource.tf
+++ b/examples/resources/astronomer_deployment/resource.tf
@@ -5,7 +5,7 @@ resource "astronomer_deployment" "standard_deployment" {
   default_task_pod_memory = "1Gi"
   description             = "A Standard Deployment"
   executor                = "CELERY"
-  is_dag_deploy_enforced  = true
+  is_dag_deploy_enabled   = true
   is_cicd_enforced        = true
   is_high_availability    = true
   name                    = "Test Deployment TF"
@@ -23,6 +23,18 @@ resource "astronomer_deployment" "standard_deployment" {
       min_worker_count : 1,
       name : "default",
       worker_concurrency : 1,
+    },
+  ]
+  environment_variables = [
+    {
+      is_secret : true,
+      key : "AWS_ACCESS_SECRET_KEY",
+      value : "SECRET_VALUE",
+    },
+    {
+      is_secret : false,
+      key : "AWS_ACCESS_KEY_ID",
+      value : "NOT_SECRET",
     },
   ]
 }

--- a/internal/api/deployment.go
+++ b/internal/api/deployment.go
@@ -83,7 +83,7 @@ type DeploymentResponse struct {
 	ResourceQuotaCpu         string                        `json:"resourceQuotaCpu"`
 	ResourceQuotaMemory      string                        `json:"resourceQuotaMemory"`
 	RuntimeVersion           string                        `json:"runtimeVersion"`
-	SchedulerAu              int                           `json:"schedulerAu"`
+	SchedulerAu              string                        `json:"schedulerAu"`
 	SchedulerCpu             string                        `json:"schedulerCpu"`
 	SchedulerMemory          string                        `json:"schedulerMemory"`
 	SchedulerReplicas        int                           `json:"schedulerReplicas"`

--- a/internal/api/deployment.go
+++ b/internal/api/deployment.go
@@ -83,7 +83,7 @@ type DeploymentResponse struct {
 	ResourceQuotaCpu         string                        `json:"resourceQuotaCpu"`
 	ResourceQuotaMemory      string                        `json:"resourceQuotaMemory"`
 	RuntimeVersion           string                        `json:"runtimeVersion"`
-	SchedulerAu              string                        `json:"schedulerAu"`
+	SchedulerAu              int                           `json:"schedulerAu"`
 	SchedulerCpu             string                        `json:"schedulerCpu"`
 	SchedulerMemory          string                        `json:"schedulerMemory"`
 	SchedulerReplicas        int                           `json:"schedulerReplicas"`
@@ -120,8 +120,8 @@ type WorkerQueue struct {
 }
 
 type SchedulerRequest struct {
-	Au       string `json:"au"`
-	Replicas int    `json:"replicas"`
+	Au       int `json:"au"`
+	Replicas int `json:"replicas"`
 }
 
 type DeploymentCreateRequest struct {
@@ -140,7 +140,7 @@ type DeploymentCreateRequest struct {
 	Region               string                       `json:"region,omitempty"`
 	ResourceQuotaCpu     string                       `json:"resourceQuotaCpu"`
 	ResourceQuotaMemory  string                       `json:"resourceQuotaMemory"`
-	Scheduler            SchedulerRequest             `json:"scheduler"`
+	Scheduler            *SchedulerRequest            `json:"scheduler"`
 	SchedulerSize        string                       `json:"schedulerSize"`
 	TaskPodNodePoolId    string                       `json:"taskPodNodePoolId"`
 	Type                 string                       `json:"type"`
@@ -161,7 +161,7 @@ type DeploymentUpdateRequest struct {
 	Name                 string                       `json:"name"`
 	ResourceQuotaCpu     string                       `json:"resourceQuotaCpu"`
 	ResourceQuotaMemory  string                       `json:"resourceQuotaMemory"`
-	Scheduler            SchedulerRequest             `json:"scheduler"`
+	Scheduler            *SchedulerRequest            `json:"scheduler"`
 	SchedulerSize        string                       `json:"schedulerSize"`
 	TaskPodNodePoolId    string                       `json:"taskPodNodePoolId"`
 	Type                 string                       `json:"type,omitempty"`

--- a/internal/api/deployment.go
+++ b/internal/api/deployment.go
@@ -125,26 +125,27 @@ type SchedulerRequest struct {
 }
 
 type DeploymentCreateRequest struct {
-	AstroRuntimeVersion  string           `json:"astroRuntimeVersion"`
-	CloudProvider        string           `json:"cloudProvider,omitempty"`
-	ClusterId            string           `json:"clusterId,omitempty"`
-	DefaultTaskPodCpu    string           `json:"defaultTaskPodCpu"`
-	DefaultTaskPodMemory string           `json:"defaultTaskPodMemory"`
-	Description          string           `json:"description"`
-	Executor             string           `json:"executor"`
-	IsCicdEnforced       bool             `json:"isCicdEnforced"`
-	IsDagDeployEnabled   bool             `json:"isDagDeployEnabled"`
-	IsHighAvailability   bool             `json:"isHighAvailability"`
-	Name                 string           `json:"name"`
-	Region               string           `json:"region,omitempty"`
-	ResourceQuotaCpu     string           `json:"resourceQuotaCpu"`
-	ResourceQuotaMemory  string           `json:"resourceQuotaMemory"`
-	Scheduler            SchedulerRequest `json:"scheduler"`
-	SchedulerSize        string           `json:"schedulerSize"`
-	TaskPodNodePoolId    string           `json:"taskPodNodePoolId"`
-	Type                 string           `json:"type"`
-	WorkerQueues         []WorkerQueue    `json:"workerQueues"`
-	WorkspaceId          string           `json:"workspaceId"`
+	AstroRuntimeVersion  string                       `json:"astroRuntimeVersion"`
+	CloudProvider        string                       `json:"cloudProvider,omitempty"`
+	ClusterId            string                       `json:"clusterId,omitempty"`
+	DefaultTaskPodCpu    string                       `json:"defaultTaskPodCpu"`
+	DefaultTaskPodMemory string                       `json:"defaultTaskPodMemory"`
+	Description          string                       `json:"description"`
+	EnvironmentVariables []EnvironmentVariableRequest `json:"environmentVariables"`
+	Executor             string                       `json:"executor"`
+	IsCicdEnforced       bool                         `json:"isCicdEnforced"`
+	IsDagDeployEnabled   bool                         `json:"isDagDeployEnabled"`
+	IsHighAvailability   bool                         `json:"isHighAvailability"`
+	Name                 string                       `json:"name"`
+	Region               string                       `json:"region,omitempty"`
+	ResourceQuotaCpu     string                       `json:"resourceQuotaCpu"`
+	ResourceQuotaMemory  string                       `json:"resourceQuotaMemory"`
+	Scheduler            SchedulerRequest             `json:"scheduler"`
+	SchedulerSize        string                       `json:"schedulerSize"`
+	TaskPodNodePoolId    string                       `json:"taskPodNodePoolId"`
+	Type                 string                       `json:"type"`
+	WorkerQueues         []WorkerQueue                `json:"workerQueues"`
+	WorkspaceId          string                       `json:"workspaceId"`
 }
 
 type DeploymentUpdateRequest struct {

--- a/internal/api/deployment.go
+++ b/internal/api/deployment.go
@@ -126,8 +126,8 @@ type SchedulerRequest struct {
 
 type DeploymentCreateRequest struct {
 	AstroRuntimeVersion  string           `json:"astroRuntimeVersion"`
-	ClusterId            string           `json:"clusterId,omitempty"`
 	CloudProvider        string           `json:"cloudProvider,omitempty"`
+	ClusterId            string           `json:"clusterId,omitempty"`
 	DefaultTaskPodCpu    string           `json:"defaultTaskPodCpu"`
 	DefaultTaskPodMemory string           `json:"defaultTaskPodMemory"`
 	Description          string           `json:"description"`
@@ -139,7 +139,7 @@ type DeploymentCreateRequest struct {
 	Region               string           `json:"region,omitempty"`
 	ResourceQuotaCpu     string           `json:"resourceQuotaCpu"`
 	ResourceQuotaMemory  string           `json:"resourceQuotaMemory"`
-	Scheduler            SchedulerRequest `json:"scheduler	"`
+	Scheduler            SchedulerRequest `json:"scheduler"`
 	SchedulerSize        string           `json:"schedulerSize"`
 	TaskPodNodePoolId    string           `json:"taskPodNodePoolId"`
 	Type                 string           `json:"type"`
@@ -160,9 +160,12 @@ type DeploymentUpdateRequest struct {
 	Name                 string                       `json:"name"`
 	ResourceQuotaCpu     string                       `json:"resourceQuotaCpu"`
 	ResourceQuotaMemory  string                       `json:"resourceQuotaMemory"`
+	Scheduler            SchedulerRequest             `json:"scheduler"`
 	SchedulerSize        string                       `json:"schedulerSize"`
+	TaskPodNodePoolId    string                       `json:"taskPodNodePoolId"`
 	Type                 string                       `json:"type,omitempty"`
 	WorkerQueues         []WorkerQueue                `json:"workerQueues"`
+	WorkloadIdentity     string                       `json:"workloadIdentity"`
 	WorkspaceId          string                       `json:"workspaceId"`
 }
 

--- a/internal/provider/deployment_data_source.go
+++ b/internal/provider/deployment_data_source.go
@@ -38,7 +38,6 @@ func (d *DeploymentDataSource) Metadata(ctx context.Context, req datasource.Meta
 
 func (d *DeploymentDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Astronomer Deployment Resource",
 
 		Attributes: map[string]schema.Attribute{

--- a/internal/provider/deployment_data_source_test.go
+++ b/internal/provider/deployment_data_source_test.go
@@ -28,7 +28,7 @@ func TestDeploymentDataSource(t *testing.T) {
 func testDeploymentDataSourceConfig(workspaceName string) string {
 	orgId := os.Getenv("ORGANIZATION_ID")
 	return fmt.Sprintf(`
-provider "astronomer" {
+provider "astronomer" {	
 	organization_id = %[1]q
 }
 
@@ -45,7 +45,7 @@ resource "astronomer_deployment" "test" {
 	default_task_pod_memory = "1Gi"
 	description = "A Standard Deployment"
 	executor = "CELERY"
-	is_dag_deploy_enforced = true
+	is_dag_deploy_enabled = true
 	is_cicd_enforced = true
 	is_high_availability = true
 	name = "Test Deployment TF"

--- a/internal/provider/deployment_data_source_test.go
+++ b/internal/provider/deployment_data_source_test.go
@@ -50,8 +50,8 @@ resource "astronomer_deployment" "test" {
 	is_high_availability = true
 	name = "Test Deployment TF"
 	region = "us-east-1"
-	resource_quota_cpu = "160"
-	resource_quota_memory = "320Gi"
+	resource_quota_cpu = "1"
+	resource_quota_memory = "2Gi"
 	scheduler_size = "MEDIUM"
 	type = "STANDARD"
 	workspace_id = astronomer_workspace.test.id

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -390,7 +390,7 @@ func loadWorkerQueuesFromTFState(data DeploymentResourceModel) []api.WorkerQueue
 }
 
 func loadEnvironmentVariablesFromTFState(data DeploymentResourceModel) []api.EnvironmentVariableRequest {
-	var envVars []api.EnvironmentVariableRequest
+	var envVars []api.EnvironmentVariableRequest = []api.EnvironmentVariableRequest{}
 	for _, value := range data.EnvironmentVariables {
 		envVars = append(envVars, api.EnvironmentVariableRequest{
 			IsSecret: value.IsSecret.ValueBool(),

--- a/internal/provider/deployment_resource_test.go
+++ b/internal/provider/deployment_resource_test.go
@@ -20,7 +20,7 @@ func TestAccDeploymentResource(t *testing.T) {
 					resource.TestCheckResourceAttr("astronomer_deployment.test", "astro_runtime_version", "9.1.0"),
 					resource.TestCheckResourceAttr("astronomer_deployment.test", "is_high_availability", "true"),
 					resource.TestCheckResourceAttr("astronomer_deployment.test", "is_cicd_enforced", "true"),
-					resource.TestCheckResourceAttr("astronomer_deployment.test", "is_dag_deploy_enforced", "true"),
+					resource.TestCheckResourceAttr("astronomer_deployment.test", "is_dag_deploy_enabled", "true"),
 				),
 			},
 			{
@@ -59,7 +59,7 @@ resource "astronomer_deployment" "test" {
 	default_task_pod_memory = "1Gi"
 	description = "A Standard Deployment"
 	executor = "CELERY"
-	is_dag_deploy_enforced = true
+	is_dag_deploy_enabled = true
 	is_cicd_enforced = true
 	is_high_availability = true
 	name = %[2]q


### PR DESCRIPTION
Changes: `is_dag_deploy_enforced` -> `is_dag_deploy_enabled`

Adds: `environment_variables` and `task_pod_node_pool_id` variables


Closes #12 