### PR TITLE
Add astro go sdk from remote source

### DIFF
--- a/internal/api/go.mod
+++ b/internal/api/go.mod
@@ -1,3 +1,5 @@
 module github.com/openglshaders/astronomer-api/v2
 
 go 1.21.5
+
+require github.com/GK-Consulting/astronomer-sdk-golang v0.0.0-20240113021839-b254f3ca53e3 // indirect

--- a/internal/api/go.sum
+++ b/internal/api/go.sum
@@ -1,0 +1,8 @@
+github.com/GK-Consulting/astronomer-sdk-golang v0.0.0-20240112134347-7871ce8cf35c h1:e038+7gHE2ZayZMEevTm4GzHVrME/MccVfQ4n/78nWw=
+github.com/GK-Consulting/astronomer-sdk-golang v0.0.0-20240112134347-7871ce8cf35c/go.mod h1:2ne8To+hc2L3UJO49yOLwsnLtv/6ZJh1aG0ZUdY2bgg=
+github.com/GK-Consulting/astronomer-sdk-golang v0.0.0-20240113021839-b254f3ca53e3 h1:g3vahC5u7lHHR7mtADSDCHjhMRD0/g1njsrlMstEVdw=
+github.com/GK-Consulting/astronomer-sdk-golang v0.0.0-20240113021839-b254f3ca53e3/go.mod h1:mG+Rfvw0CbLG3rw17333hEdrdTQu4N+un6MdGX3xvTI=
+github.com/GK-Consulting/astronomer-sdk-golang/iam v0.0.0-20240112133119-079f41d9491d h1:oC4/PIuTejLvCv1fl1a473lPzXCK8XJU6gvmDtkg4VE=
+github.com/GK-Consulting/astronomer-sdk-golang/iam v0.0.0-20240112133119-079f41d9491d/go.mod h1:mmJ2dVVyx1EvfDdxE4kuBShO5Kh7syIqkex2wxVwRqw=
+github.com/GK-Consulting/astronomer-sdk-golang/platform v0.0.0-20240112133119-079f41d9491d h1:SLB8akYIBCg12woQdvxw1Ra7OV0qngJ/nFkUT14GIFw=
+github.com/GK-Consulting/astronomer-sdk-golang/platform v0.0.0-20240112133119-079f41d9491d/go.mod h1:w1HrqjDWgoxzr2dnUsOE8vZ/RpqJVnPOpckhMagJDsY=


### PR DESCRIPTION
This confirms that we can access our auto-gen API client from [it's repo](https://github.com/GK-Consulting/astronomer-sdk-golang). Tests will currently fail since the repo is private, we'll need to tweak our CI or make it public.

 - [x] `go get ...`
- [x] `go get -u ...`
- [x] `go build -v .` from root directory still produces functional executable
- [ ] Functionally use module in some way and do build